### PR TITLE
Potential fix for code scanning alert no. 3: Failure to use secure cookies

### DIFF
--- a/src/main/java/de/bahmut/kindleproxy/service/UserSettingsService.java
+++ b/src/main/java/de/bahmut/kindleproxy/service/UserSettingsService.java
@@ -114,6 +114,8 @@ public class UserSettingsService {
             return;
         }
         final Cookie cookie = new Cookie(COOKIE_USER_SETTINGS, convertToCookieValue(settings));
+        cookie.setSecure(true);
+        cookie.setHttpOnly(true);
         response.addCookie(cookie);
         this.settings = settings;
         cacheService.invalidItemsByConditionIdentifier(userIdentifier.toString());


### PR DESCRIPTION
Potential fix for [https://github.com/kaiser-chris/kindle-proxy/security/code-scanning/3](https://github.com/kaiser-chris/kindle-proxy/security/code-scanning/3)

Set security attributes on the cookie before calling `response.addCookie(cookie)` in `saveSettings`.

Best fix in this file/region:
- In `src/main/java/de/bahmut/kindleproxy/service/UserSettingsService.java`, inside `saveSettings(...)` around lines 116–117:
  - Keep cookie creation as-is.
  - Add `cookie.setSecure(true);` before `response.addCookie(cookie);`.
  - (Recommended hardening that does not change core functionality) add `cookie.setHttpOnly(true);` as well.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
